### PR TITLE
Forcing SSL is a 301 Permanent Redirect.

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ module.exports = function forceSSL(port, hostname) {
     var httpsPort = port || 443;
     var urlObject = url.parse('http://' + this.request.header.host);
     var httpsHost = hostname || urlObject.hostname;
+    this.response.status = 301;
     this.response.redirect('https://' + httpsHost + ':' + httpsPort + this.request.url);
   };
 };


### PR DESCRIPTION
The default response status code of "302 Temporary Redirect" is somewhat misleading. Forcing SSL is a permanent redirection, not temporary redirection. From the viewpoint of a crawler, using 302s means that the crawler should return to the 302'd URL in the future, while using 301s means that the crawler should replace the 301'd URL with the redirected URL and not try the 301'd URL again. This could be an important distinction soon as Google now prioritizes HTTPS over HTTP ( http://www.googlewebmastercentral.blogspot.ch/2014/08/https-as-ranking-signal.html ). Google has not stated that 302 redirects of insecure content will be given less of a signal boost from the HTTPS redirect but amongst the discussion there was mention of a HTTPS canonical URL being receiving a higher boost than a HTTP canonical URL that gets 302 redirected to HTTPS.

Note: it might be worth making this an optional change, as some people may only want to temporarily change their app/site to HTTPS. The only scenario I could come up with was that people might want the option of stopping paying for a SSL cert and not losing their canonical links. Seems like a bad practice, though, so I think this is the proper implementation.
